### PR TITLE
feat(ae): generate new accounts on startup

### DIFF
--- a/src/utils/aeternity.js
+++ b/src/utils/aeternity.js
@@ -5,8 +5,6 @@ import POS_CONTRACT_INTERFACE from './pos-contract-interface.aes';
 const TESTNET_URL = 'https://testnet.aeternity.io';
 const COMPILER_URL = 'https://compiler.aepps.com';
 
-const PUBLIC_KEY = 'ak_BSr9fg46v1iEs7opXEu4i8GjJ5YBassrAf6L2ZBNefbUDJZcq';
-const PRIVATE_KEY = '333ba7ad1f085eb77004d2efbbce9c799f0dae92355f5fe07388bde3b3e8235a17b7d65b741ae288c56638f004e42d52c0e0442b94f1bdd0689b2dae1c65511c';
 const TOKEN_CONTRACT_ADDRESS = 'ct_45FezzKwHQyenzW8SZxFJUKVWtZ4UMgVG4kAbeKcAAqsA91K3';
 const POS_CONTRACT_ADDRESS = 'ct_2ndDv1QzkrgXfr1UJ2pnpjMZpTJDB4GuytH143bjNMTGRbBkL7';
 
@@ -18,11 +16,20 @@ const aeternity = {
   posContractAddress: POS_CONTRACT_ADDRESS,
 };
 
-aeternity.init = async () => {
+aeternity.generateAccount = () => {
+  return Crypto.generateKeyPair();
+}
+
+aeternity.checkBalance = async () => {
+  const address = await aeternity.client.address();
+  return aeternity.client.getBalance(address);
+}
+
+aeternity.init = async ({publicKey, secretKey}) => {
   aeternity.client = await Universal({
     compilerUrl: COMPILER_URL,
     nodes: [{name: 'testnet', instance: await Node({url: TESTNET_URL})}],
-    accounts: [MemoryAccount({keypair: {secretKey: PRIVATE_KEY, publicKey: PUBLIC_KEY}})],
+    accounts: [MemoryAccount({keypair: {secretKey, publicKey}})],
   });
   aeternity.token = await aeternity.client.getContractInstance(FUNGIBLE_TOKEN_CONTRACT_INTERFACE, {contractAddress: TOKEN_CONTRACT_ADDRESS})
   aeternity.pos = await aeternity.client.getContractInstance(POS_CONTRACT_INTERFACE, {contractAddress: POS_CONTRACT_ADDRESS})

--- a/src/views/PoS.vue
+++ b/src/views/PoS.vue
@@ -178,7 +178,7 @@ export default {
     },
     async checkPaid() {
       if (this.state === 'REQUEST_PAYMENT') {
-        const hasPaid = await aeternity.pos.methods.has_paid(this.invoiceId).then(r => r.decodedResult);
+        const hasPaid = await aeternity.pos.methods.has_paid(this.invoiceId).then(r => r.decodedResult).catch(console.error);
         if (hasPaid) {
           this.state = 'PAID'
           clearInterval(this.checkPaidInterval)


### PR DESCRIPTION
What:
- adds local account
- adds new page that asks for funding
- checks funding on startup

Why:
If the same keypair is in use of more than one PoS the following situation will happen (and happened during testing):
PoS1 generates an invoice (nonce 1) and dry runs for updates (nonce 2)
PoS2 generates an invoice (nonce 2) and dry runs for updates (nonce 3)

When PoS2 generates the invoice, the dry runs from PoS1 fail. By separating it into accounts, the nonce issue will not appear anymore.